### PR TITLE
Enhance event and user APIs and seed data

### DIFF
--- a/Crew.Api/Controllers/EventsController.cs
+++ b/Crew.Api/Controllers/EventsController.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Crew.Api.Data;
 using Crew.Api.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -32,18 +35,28 @@ public class EventsController : ControllerBase
     public async Task<ActionResult<Event>> Create(Event newEvent)
     {
         newEvent.Id = _context.Events.Any() ? _context.Events.Max(e => e.Id) + 1 : 1;
+        SanitizeEvent(newEvent);
 
-        // 限制最多 5 张图片
-        if (newEvent.ImageUrls.Count > 5)
+        if (newEvent.StartTime == default)
         {
-            newEvent.ImageUrls = newEvent.ImageUrls.Take(5).ToList();
+            newEvent.StartTime = DateTime.UtcNow;
         }
 
-        // 自动设置封面
-        if (string.IsNullOrEmpty(newEvent.CoverImageUrl) && newEvent.ImageUrls.Any())
+        if (newEvent.EndTime == default)
         {
-            newEvent.CoverImageUrl = newEvent.ImageUrls[0];
+            newEvent.EndTime = newEvent.StartTime;
         }
+
+        if (newEvent.EndTime < newEvent.StartTime)
+        {
+            return BadRequest("End time cannot be earlier than the start time.");
+        }
+
+        newEvent.CreatedAt = DateTime.UtcNow;
+        newEvent.LastUpdated = newEvent.CreatedAt;
+        newEvent.ExpectedParticipants = Math.Max(0, newEvent.ExpectedParticipants);
+        newEvent.ImageUrls = NormalizeImageUrls(newEvent.ImageUrls);
+        newEvent.CoverImageUrl = ResolveCoverImage(newEvent.CoverImageUrl, newEvent.ImageUrls);
 
         _context.Events.Add(newEvent);
         await _context.SaveChangesAsync();
@@ -56,16 +69,33 @@ public class EventsController : ControllerBase
         var ev = await _context.Events.FindAsync(id);
         if (ev == null) return NotFound();
 
+        SanitizeEvent(updatedEvent);
+        if (updatedEvent.StartTime != default && updatedEvent.EndTime != default &&
+            updatedEvent.EndTime < updatedEvent.StartTime)
+        {
+            return BadRequest("End time cannot be earlier than the start time.");
+        }
+
         ev.Title = updatedEvent.Title;
+        ev.Type = updatedEvent.Type;
+        ev.Status = updatedEvent.Status;
+        ev.Organizer = updatedEvent.Organizer;
         ev.Location = updatedEvent.Location;
         ev.Description = updatedEvent.Description;
+        ev.ExpectedParticipants = Math.Max(0, updatedEvent.ExpectedParticipants);
+        if (updatedEvent.StartTime != default)
+        {
+            ev.StartTime = updatedEvent.StartTime;
+        }
+        if (updatedEvent.EndTime != default)
+        {
+            ev.EndTime = updatedEvent.EndTime;
+        }
         ev.Latitude = updatedEvent.Latitude;
         ev.Longitude = updatedEvent.Longitude;
-        // 限制最多 5 张图片
-        ev.ImageUrls = updatedEvent.ImageUrls.Take(5).ToList();
-        ev.CoverImageUrl = string.IsNullOrEmpty(updatedEvent.CoverImageUrl) && updatedEvent.ImageUrls.Any()
-            ? updatedEvent.ImageUrls[0]
-            : updatedEvent.CoverImageUrl;
+        ev.ImageUrls = NormalizeImageUrls(updatedEvent.ImageUrls);
+        ev.CoverImageUrl = ResolveCoverImage(updatedEvent.CoverImageUrl, ev.ImageUrls);
+        ev.LastUpdated = DateTime.UtcNow;
 
         await _context.SaveChangesAsync();
         return NoContent();
@@ -83,14 +113,110 @@ public class EventsController : ControllerBase
     }
 
     [HttpGet("search")]
-    public async Task<ActionResult<IEnumerable<Event>>> SearchEvents(string query, double? lat, double? lng, double? radiusKm = 10)
+    public async Task<ActionResult<IEnumerable<Event>>> SearchEvents(
+        string? query,
+        double? lat,
+        double? lng,
+        double? radiusKm = 10,
+        string? type = null,
+        string? status = null)
     {
         var events = _context.Events.AsQueryable();
         if (!string.IsNullOrEmpty(query))
         {
-            events = events.Where(e => e.Title.Contains(query, StringComparison.OrdinalIgnoreCase));
+            var likeQuery = $"%{query.Trim()}%";
+            events = events.Where(e =>
+                EF.Functions.Like(e.Title, likeQuery) ||
+                EF.Functions.Like(e.Description, likeQuery) ||
+                EF.Functions.Like(e.Location, likeQuery));
         }
 
-        return Ok(await events.ToListAsync());
+        var result = await events.ToListAsync();
+
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            var normalizedType = type.Trim();
+            result = result
+                .Where(e => !string.IsNullOrEmpty(e.Type) &&
+                            string.Equals(e.Type, normalizedType, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            var normalizedStatus = status.Trim();
+            result = result
+                .Where(e => !string.IsNullOrEmpty(e.Status) &&
+                            string.Equals(e.Status, normalizedStatus, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (lat.HasValue && lng.HasValue && radiusKm.HasValue && radiusKm.Value > 0)
+        {
+            var originLat = lat.Value;
+            var originLng = lng.Value;
+            var radius = radiusKm.Value;
+
+            result = result
+                .Where(e => CalculateDistanceKm(originLat, originLng, e.Latitude, e.Longitude) <= radius)
+                .ToList();
+        }
+
+        return Ok(result);
     }
+
+    private static void SanitizeEvent(Event eventToSanitize)
+    {
+        eventToSanitize.Title = eventToSanitize.Title?.Trim() ?? string.Empty;
+        eventToSanitize.Type = eventToSanitize.Type?.Trim() ?? string.Empty;
+        eventToSanitize.Status = eventToSanitize.Status?.Trim() ?? string.Empty;
+        eventToSanitize.Organizer = eventToSanitize.Organizer?.Trim() ?? string.Empty;
+        eventToSanitize.Location = eventToSanitize.Location?.Trim() ?? string.Empty;
+        eventToSanitize.Description = eventToSanitize.Description?.Trim() ?? string.Empty;
+        eventToSanitize.CoverImageUrl = eventToSanitize.CoverImageUrl?.Trim() ?? string.Empty;
+    }
+
+    private static List<string> NormalizeImageUrls(IEnumerable<string>? imageUrls)
+    {
+        if (imageUrls == null)
+        {
+            return new List<string>();
+        }
+
+        return imageUrls
+            .Where(url => !string.IsNullOrWhiteSpace(url))
+            .Take(5)
+            .Select(url => url.Trim())
+            .ToList();
+    }
+
+    private static string ResolveCoverImage(string? coverImageUrl, IReadOnlyList<string> imageUrls)
+    {
+        if (!string.IsNullOrWhiteSpace(coverImageUrl))
+        {
+            return coverImageUrl.Trim();
+        }
+
+        return imageUrls.Any() ? imageUrls[0] : string.Empty;
+    }
+
+    private static double CalculateDistanceKm(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double EarthRadiusKm = 6371.0;
+
+        var dLat = DegreesToRadians(lat2 - lat1);
+        var dLon = DegreesToRadians(lon2 - lon1);
+        lat1 = DegreesToRadians(lat1);
+        lat2 = DegreesToRadians(lat2);
+
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(lat1) * Math.Cos(lat2) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+
+        return EarthRadiusKm * c;
+    }
+
+    private static double DegreesToRadians(double degrees)
+        => degrees * (Math.PI / 180.0);
 }

--- a/Crew.Api/Controllers/UsersController.cs
+++ b/Crew.Api/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using System;
 using Crew.Api.Data;
 using Crew.Api.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -32,6 +33,7 @@ public class UsersController : ControllerBase
     public async Task<ActionResult<User>> Create(User newUser)
     {
         newUser.Id = _context.Users.Any() ? _context.Users.Max(u => u.Id) + 1 : 1;
+        NormalizeUser(newUser);
         _context.Users.Add(newUser);
         await _context.SaveChangesAsync();
         return CreatedAtAction(nameof(GetById), new { id = newUser.Id }, newUser);
@@ -43,8 +45,18 @@ public class UsersController : ControllerBase
         var user = await _context.Users.FindAsync(id);
         if (user == null) return NotFound();
 
+        NormalizeUser(updatedUser);
         user.UserName = updatedUser.UserName;
         user.Email = updatedUser.Email;
+        user.Uid = updatedUser.Uid;
+        user.Name = updatedUser.Name;
+        user.Bio = updatedUser.Bio;
+        user.Avatar = updatedUser.Avatar;
+        user.Cover = updatedUser.Cover;
+        user.Followers = Math.Max(0, updatedUser.Followers);
+        user.Following = Math.Max(0, updatedUser.Following);
+        user.Likes = Math.Max(0, updatedUser.Likes);
+        user.Followed = updatedUser.Followed;
         await _context.SaveChangesAsync();
         return NoContent();
     }
@@ -58,5 +70,19 @@ public class UsersController : ControllerBase
         _context.Users.Remove(user);
         await _context.SaveChangesAsync();
         return NoContent();
+    }
+
+    private static void NormalizeUser(User user)
+    {
+        user.UserName = user.UserName?.Trim() ?? string.Empty;
+        user.Email = user.Email?.Trim() ?? string.Empty;
+        user.Uid = user.Uid?.Trim() ?? string.Empty;
+        user.Name = user.Name?.Trim() ?? string.Empty;
+        user.Bio = user.Bio?.Trim() ?? string.Empty;
+        user.Avatar = user.Avatar?.Trim() ?? string.Empty;
+        user.Cover = user.Cover?.Trim() ?? string.Empty;
+        user.Followers = Math.Max(0, user.Followers);
+        user.Following = Math.Max(0, user.Following);
+        user.Likes = Math.Max(0, user.Likes);
     }
 }

--- a/Crew.Api/Utils/SeedDataService.cs
+++ b/Crew.Api/Utils/SeedDataService.cs
@@ -1,186 +1,341 @@
-﻿using Crew.Api.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Crew.Api.Data;
 using Crew.Api.Models;
 
-namespace Crew.Api.Utils
+namespace Crew.Api.Utils;
+
+public static class SeedDataService
 {
-    public static class SeedDataService
+    public static void SeedDatabase(EventsDbContext context)
     {
-        public static void SeedDatabase(EventsDbContext context)
+        if (!context.Events.Any())
         {
-            if (!context.Events.Any())
-            {
-                context.Events.AddRange(
-                            new Event
-                            {
-                                Id = 1,
-                                Title = "City Walk",
-                                Location = "Berlin",
-                                Description = "A walk through the city center",
-                                Latitude = 52.520008,
-                                Longitude = 13.404954,
-                                ImageUrls = new List<string>
-                                {
-                                        "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 2,
-                                Title = "Museum Tour",
-                                Location = "Paris",
-                                Description = "A tour of the Louvre Museum",
-                                Latitude = 48.856614,
-                                Longitude = 2.3522219,
-                                ImageUrls = new List<string>
-                                {
-                                    "https://images.unsplash.com/photo-1520975928316-56c6f6f163a4",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 3,
-                                Title = "Coffee Meetup",
-                                Location = "Paris",
-                                Description = "聊聊创业和生活",
-                                Latitude = 48.8566,
-                                Longitude = 2.3522,
-                                ImageUrls = new List<string>
-                                {
-                                    "https://images.unsplash.com/photo-1519681393784-d120267933ba",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 4,
-                                Title = "Art Gallery Walk",
-                                Location = "Berlin",
-                                Description = "一起探索当代艺术",
-                                Latitude = 51.5074,
-                                Longitude = -0.1278,
-                                ImageUrls = new List<string>
-                                {
-                                    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 5,
-                                Title = "Hiking Adventure",
-                                Location = "Berlin",
-                                Description = "阿尔卑斯山徒步",
-                                Latitude = 46.2044,
-                                Longitude = 6.1432,
-                                ImageUrls = new List<string>
-                                {
-                                    "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 6,
-                                Title = "Board Games Night",
-                                Location = "Paris",
-                                Description = "桌游+社交",
-                                Latitude = 52.5200,
-                                Longitude = 13.4050,
-                                ImageUrls = new List<string>
-                                {
-                                    "https://images.unsplash.com/photo-1472214103451-9374bd1c798e",
-"https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-    "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66",
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                            new Event
-                            {
-                                Id = 7,
-                                Title = "Live Music",
-                                Location = "Berlin",
-                                Description = "一起听爵士",
-                                Latitude = 41.9028,
-                                Longitude = 12.4964,
-                                ImageUrls = new List<string>
-                                {
-                                },
-                                CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                            },
-                                               new Event
-                                               {
-                                                   Id = 8,
-                                                   Title = "Live Music",
-                                                   Location = "Milan",
-                                                   Description = "一起听音乐",
-                                                   Latitude = 31.9028,
-                                                   Longitude = 12.4964,
-                                                   ImageUrls = new List<string>
-                                                   {
-                                                       "https://images.unsplash.com/photo-1469474968028-56623f02e42e",
-                                                   },
-                                                   CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                                               },
-                                                                    new Event
-                                                                    {
-                                                                        Id = 9,
-                                                                        Title = "Sport",
-                                                                        Location = "Roma",
-                                                                        Description = "运动",
-                                                                        Latitude = 21.9028,
-                                                                        Longitude = 22.4964,
-                                                                        ImageUrls = new List<string>
-                                                   {
-                                                       "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?ixlib=rb-1.2.1",
-                                                   },
-                                                                        CoverImageUrl = "https://i.imgur.com/c7BHAnI.png"
-                                                                    }
-                        );
-                context.SaveChanges();
-            }
+            var baseTime = DateTime.UtcNow.Date.AddHours(10);
 
-            if (!context.Users.Any())
+            var seededEvents = new List<Event>
             {
-                context.Users.AddRange(
-                    new User { Id = 1, UserName = "alice", Email = "alice@example.com" },
-                    new User { Id = 2, UserName = "bob", Email = "bob@example.com" }
-                );
-                context.SaveChanges();
-            }
-
-            if (!context.Comments.Any())
-            {
-                context.Comments.Add(
-                    new Comment
+                CreateEvent(
+                    id: 1,
+                    title: "City Walk",
+                    type: "Outdoor",
+                    status: "Upcoming",
+                    organizer: "Urban Explorers",
+                    location: "Berlin",
+                    description: "A walk through the city center",
+                    expectedParticipants: 40,
+                    startTime: baseTime.AddDays(1),
+                    endTime: baseTime.AddDays(1).AddHours(2),
+                    latitude: 52.520008,
+                    longitude: 13.404954,
+                    imageUrls: new[]
                     {
-                        Id = 1,
-                        EventId = 1,
-                        UserId = 1,
-                        Content = "Looking forward to it!",
-                        CreatedAt = DateTime.UtcNow
-                    }
-                );
-                context.SaveChanges();
-            }
+                        "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee",
+                        "https://images.unsplash.com/photo-1529927066849-a6c9a73b73a0",
+                        "https://images.unsplash.com/photo-1508057198894-247b23fe5ade"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 2,
+                    title: "Museum Tour",
+                    type: "Culture",
+                    status: "Upcoming",
+                    organizer: "Art Lovers Club",
+                    location: "Paris",
+                    description: "A tour of the Louvre Museum",
+                    expectedParticipants: 30,
+                    startTime: baseTime.AddDays(2),
+                    endTime: baseTime.AddDays(2).AddHours(4),
+                    latitude: 48.856614,
+                    longitude: 2.3522219,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1520975928316-56c6f6f163a4",
+                        "https://images.unsplash.com/photo-1529429617124-aee30bd7e8f9",
+                        "https://images.unsplash.com/photo-1441974231531-c6227db76b6e"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 3,
+                    title: "Coffee Meetup",
+                    type: "Networking",
+                    status: "Upcoming",
+                    organizer: "Startup Stories",
+                    location: "Paris",
+                    description: "聊聊创业和生活",
+                    expectedParticipants: 20,
+                    startTime: baseTime.AddDays(3).AddHours(2),
+                    endTime: baseTime.AddDays(3).AddHours(4),
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1519681393784-d120267933ba",
+                        "https://images.unsplash.com/photo-1466978913421-dad2ebd01d17",
+                        "https://images.unsplash.com/photo-1470337458703-46ad1756a187"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 4,
+                    title: "Art Gallery Walk",
+                    type: "Culture",
+                    status: "Upcoming",
+                    organizer: "Creative Fridays",
+                    location: "Berlin",
+                    description: "一起探索当代艺术",
+                    expectedParticipants: 25,
+                    startTime: baseTime.AddDays(4).AddHours(1),
+                    endTime: baseTime.AddDays(4).AddHours(3),
+                    latitude: 52.5200,
+                    longitude: 13.4050,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1529101091764-c3526daf38fe",
+                        "https://images.unsplash.com/photo-1487412912498-0447578fcca8",
+                        "https://images.unsplash.com/photo-1496317899792-9d7dbcd928a1"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 5,
+                    title: "Hiking Adventure",
+                    type: "Outdoor",
+                    status: "Planning",
+                    organizer: "Alpine Treks",
+                    location: "Zurich",
+                    description: "阿尔卑斯山徒步",
+                    expectedParticipants: 18,
+                    startTime: baseTime.AddDays(7),
+                    endTime: baseTime.AddDays(7).AddHours(6),
+                    latitude: 46.2044,
+                    longitude: 6.1432,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429",
+                        "https://images.unsplash.com/photo-1489515217757-5fd1be406fef",
+                        "https://images.unsplash.com/photo-1469474968028-56623f02e42e"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 6,
+                    title: "Board Games Night",
+                    type: "Community",
+                    status: "Completed",
+                    organizer: "Tabletop Circle",
+                    location: "Paris",
+                    description: "桌游+社交",
+                    expectedParticipants: 16,
+                    startTime: baseTime.AddDays(-2).AddHours(18),
+                    endTime: baseTime.AddDays(-2).AddHours(22),
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1472214103451-9374bd1c798e",
+                        "https://images.unsplash.com/photo-1489515217757-5fd1be406fef",
+                        "https://images.unsplash.com/photo-1521737604893-d14cc237f11d"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 7,
+                    title: "Live Jazz Night",
+                    type: "Music",
+                    status: "Upcoming",
+                    organizer: "Blue Note Crew",
+                    location: "Berlin",
+                    description: "一起听爵士",
+                    expectedParticipants: 60,
+                    startTime: baseTime.AddDays(5).AddHours(20),
+                    endTime: baseTime.AddDays(5).AddHours(23),
+                    latitude: 52.520008,
+                    longitude: 13.404954,
+                    imageUrls: Array.Empty<string>(),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 8,
+                    title: "Open Air Concert",
+                    type: "Music",
+                    status: "Upcoming",
+                    organizer: "Milan Sound Collective",
+                    location: "Milan",
+                    description: "一起听音乐",
+                    expectedParticipants: 120,
+                    startTime: baseTime.AddDays(6).AddHours(19),
+                    endTime: baseTime.AddDays(6).AddHours(23),
+                    latitude: 45.4642,
+                    longitude: 9.19,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1469474968028-56623f02e42e",
+                        "https://images.unsplash.com/photo-1497032628192-86f99bcd76bc",
+                        "https://images.unsplash.com/photo-1506157786151-b8491531f063"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                CreateEvent(
+                    id: 9,
+                    title: "Morning Run Club",
+                    type: "Sports",
+                    status: "Upcoming",
+                    organizer: "Roma Runners",
+                    location: "Rome",
+                    description: "运动",
+                    expectedParticipants: 35,
+                    startTime: baseTime.AddDays(8).AddHours(7),
+                    endTime: baseTime.AddDays(8).AddHours(9),
+                    latitude: 41.9028,
+                    longitude: 12.4964,
+                    imageUrls: new[]
+                    {
+                        "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee",
+                        "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66"
+                    },
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png")
+            };
+
+            context.Events.AddRange(seededEvents);
+            context.SaveChanges();
         }
 
+        if (!context.Users.Any())
+        {
+            context.Users.AddRange(
+                new User
+                {
+                    Id = 1,
+                    UserName = "alice",
+                    Email = "alice@example.com",
+                    Uid = "user-alice",
+                    Name = "Alice Lee",
+                    Bio = "Berlin-based community organizer who loves urban walks.",
+                    Avatar = "https://i.imgur.com/zY5R8dH.png",
+                    Cover = "https://i.imgur.com/3S9g6Et.png",
+                    Followers = 128,
+                    Following = 54,
+                    Likes = 640,
+                    Followed = true
+                },
+                new User
+                {
+                    Id = 2,
+                    UserName = "bob",
+                    Email = "bob@example.com",
+                    Uid = "user-bob",
+                    Name = "Bob Martin",
+                    Bio = "A Paris-based designer and museum enthusiast.",
+                    Avatar = "https://i.imgur.com/4ZQZ3p0.png",
+                    Cover = "https://i.imgur.com/2bE8wE7.png",
+                    Followers = 96,
+                    Following = 73,
+                    Likes = 480,
+                    Followed = false
+                },
+                new User
+                {
+                    Id = 3,
+                    UserName = "carol",
+                    Email = "carol@example.com",
+                    Uid = "user-carol",
+                    Name = "Carol Smith",
+                    Bio = "Event host who curates intimate coffee meetups.",
+                    Avatar = "https://i.imgur.com/V0YqR0P.png",
+                    Cover = "https://i.imgur.com/8aZPRWn.png",
+                    Followers = 205,
+                    Following = 120,
+                    Likes = 1024,
+                    Followed = false
+                }
+            );
+            context.SaveChanges();
+        }
+
+        if (!context.Comments.Any())
+        {
+            context.Comments.AddRange(
+                new Comment
+                {
+                    Id = 1,
+                    EventId = 1,
+                    UserId = 1,
+                    Content = "Looking forward to it!",
+                    CreatedAt = DateTime.UtcNow.AddDays(-2)
+                },
+                new Comment
+                {
+                    Id = 2,
+                    EventId = 2,
+                    UserId = 2,
+                    Content = "Count me in for the museum tour.",
+                    CreatedAt = DateTime.UtcNow.AddDays(-1)
+                },
+                new Comment
+                {
+                    Id = 3,
+                    EventId = 3,
+                    UserId = 3,
+                    Content = "Will there be coffee tastings?",
+                    CreatedAt = DateTime.UtcNow.AddHours(-5)
+                }
+            );
+            context.SaveChanges();
+        }
+    }
+
+    private static Event CreateEvent(
+        int id,
+        string title,
+        string type,
+        string status,
+        string organizer,
+        string location,
+        string description,
+        int expectedParticipants,
+        DateTime startTime,
+        DateTime endTime,
+        double latitude,
+        double longitude,
+        IEnumerable<string> imageUrls,
+        string coverImageUrl)
+    {
+        var images = imageUrls?
+            .Where(url => !string.IsNullOrWhiteSpace(url))
+            .Select(url => url.Trim())
+            .Take(5)
+            .ToList() ?? new List<string>();
+
+        var cover = !string.IsNullOrWhiteSpace(coverImageUrl)
+            ? coverImageUrl.Trim()
+            : images.FirstOrDefault() ?? string.Empty;
+
+        var createdAt = startTime.AddDays(-7);
+        var lastUpdated = createdAt.AddDays(2);
+        if (lastUpdated < createdAt)
+        {
+            lastUpdated = createdAt;
+        }
+
+        if (endTime < startTime)
+        {
+            endTime = startTime;
+        }
+
+        return new Event
+        {
+            Id = id,
+            Title = title,
+            Type = type,
+            Status = status,
+            Organizer = organizer,
+            Location = location,
+            Description = description,
+            ExpectedParticipants = Math.Max(0, expectedParticipants),
+            StartTime = startTime,
+            EndTime = endTime,
+            CreatedAt = createdAt,
+            LastUpdated = lastUpdated,
+            Latitude = latitude,
+            Longitude = longitude,
+            ImageUrls = images,
+            CoverImageUrl = cover
+        };
     }
 }


### PR DESCRIPTION
## Summary
- expand the event endpoints to sanitize inputs, enforce scheduling rules, limit media, and add flexible query filtering by type, status, and location radius
- update user endpoints to normalize profile fields and keep all counters in sync with the domain model
- refresh the in-memory seed data to populate the new event metadata, richer user profiles, and multiple comments

## Testing
- `dotnet build Crew.Api.sln` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc68a95c24832c8dbc0fe7c3cd4454