### PR TITLE
Add Firebase Remote Config disclaimer management

### DIFF
--- a/Crew.Api/Controllers/RemoteConfigDisclaimersController.cs
+++ b/Crew.Api/Controllers/RemoteConfigDisclaimersController.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Threading;
+using Crew.Api.Models.RemoteConfig;
+using Crew.Api.Security;
+using Crew.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Crew.Api.Controllers;
+
+[ApiController]
+[Route("api/remote-config/disclaimers")]
+[Authorize(Policy = AuthorizationPolicies.RequireAdmin)]
+public class RemoteConfigDisclaimersController : ControllerBase
+{
+    private readonly IFirebaseAdminService _firebaseAdminService;
+    private readonly ILogger<RemoteConfigDisclaimersController> _logger;
+
+    public RemoteConfigDisclaimersController(
+        IFirebaseAdminService firebaseAdminService,
+        ILogger<RemoteConfigDisclaimersController> logger)
+    {
+        _firebaseAdminService = firebaseAdminService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<RemoteConfigDisclaimerDto>>> GetAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var disclaimers = await _firebaseAdminService.GetDisclaimersAsync(cancellationToken);
+            return Ok(disclaimers);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to read remote config disclaimers.");
+            return Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<RemoteConfigDisclaimerDto>> GetByIdAsync(string id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var disclaimer = await _firebaseAdminService.GetDisclaimerAsync(id, cancellationToken);
+            if (disclaimer is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(disclaimer);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to read remote config disclaimer {DisclaimerId}.", id);
+            return Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<RemoteConfigDisclaimerDto>> CreateAsync(
+        [FromBody] CreateRemoteConfigDisclaimerRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Message))
+        {
+            ModelState.AddModelError(nameof(request.Message), "Message cannot be empty or whitespace.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var disclaimer = await _firebaseAdminService.CreateDisclaimerAsync(request, cancellationToken);
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = disclaimer.Id }, disclaimer);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to create remote config disclaimer.");
+            return Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<RemoteConfigDisclaimerDto>> UpdateAsync(
+        string id,
+        [FromBody] UpdateRemoteConfigDisclaimerRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Message))
+        {
+            ModelState.AddModelError(nameof(request.Message), "Message cannot be empty or whitespace.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var disclaimer = await _firebaseAdminService.UpdateDisclaimerAsync(id, request, cancellationToken);
+            return Ok(disclaimer);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to update remote config disclaimer {DisclaimerId}.", id);
+            return Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteAsync(string id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var deleted = await _firebaseAdminService.DeleteDisclaimerAsync(id, cancellationToken);
+            if (!deleted)
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to delete remote config disclaimer {DisclaimerId}.", id);
+            return Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+}

--- a/Crew.Api/Crew.Api.csproj
+++ b/Crew.Api/Crew.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
+    <PackageReference Include="Google.Apis.FirebaseRemoteConfig.v1" Version="1.65.0.3115" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">

--- a/Crew.Api/Models/RemoteConfig/CreateRemoteConfigDisclaimerRequest.cs
+++ b/Crew.Api/Models/RemoteConfig/CreateRemoteConfigDisclaimerRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Crew.Api.Models.RemoteConfig;
+
+public class CreateRemoteConfigDisclaimerRequest
+{
+    [Required]
+    [MaxLength(2048)]
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [MaxLength(20)]
+    [JsonPropertyName("locale")]
+    public string? Locale { get; set; }
+}

--- a/Crew.Api/Models/RemoteConfig/RemoteConfigDisclaimerDto.cs
+++ b/Crew.Api/Models/RemoteConfig/RemoteConfigDisclaimerDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Crew.Api.Models.RemoteConfig;
+
+public record RemoteConfigDisclaimerDto
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("locale")]
+    public string? Locale { get; init; }
+
+    [JsonPropertyName("lastUpdatedUtc")]
+    public DateTime LastUpdatedUtc { get; init; }
+}

--- a/Crew.Api/Models/RemoteConfig/UpdateRemoteConfigDisclaimerRequest.cs
+++ b/Crew.Api/Models/RemoteConfig/UpdateRemoteConfigDisclaimerRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Crew.Api.Models.RemoteConfig;
+
+public class UpdateRemoteConfigDisclaimerRequest
+{
+    [Required]
+    [MaxLength(2048)]
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [MaxLength(20)]
+    [JsonPropertyName("locale")]
+    public string? Locale { get; set; }
+}

--- a/Crew.Api/Services/FirebaseAdminService.cs
+++ b/Crew.Api/Services/FirebaseAdminService.cs
@@ -200,9 +200,10 @@ public class FirebaseAdminService : IFirebaseAdminService
 
         try
         {
+            const string firebaseScope = FirebaseRemoteConfigService.ScopeConstants.Firebase;
             return new FirebaseRemoteConfigService(new BaseClientService.Initializer
             {
-                HttpClientInitializer = _credential.CreateScoped(FirebaseRemoteConfigService.Scope.Firebase),
+                HttpClientInitializer = _credential.CreateScoped(firebaseScope),
                 ApplicationName = "Crew.Api Remote Config",
             });
         }

--- a/Crew.Api/Services/FirebaseAdminService.cs
+++ b/Crew.Api/Services/FirebaseAdminService.cs
@@ -1,8 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Crew.Api.Models.RemoteConfig;
 using FirebaseAdmin;
 using FirebaseAdmin.Auth;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.FirebaseRemoteConfig.v1;
+using Google.Apis.FirebaseRemoteConfig.v1.Data;
+using Google.Apis.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -10,12 +18,29 @@ namespace Crew.Api.Services;
 
 public class FirebaseAdminService : IFirebaseAdminService
 {
+    private const string DefaultDisclaimersParameterKey = "disclaimers";
+
     private readonly ILogger<FirebaseAdminService> _logger;
+    private readonly GoogleCredential? _credential;
+    private readonly string? _projectId;
+    private readonly string _disclaimersParameterKey;
+    private readonly Lazy<FirebaseRemoteConfigService?> _remoteConfigService;
+    private readonly JsonSerializerOptions _serializerOptions;
 
     public FirebaseAdminService(IConfiguration configuration, ILogger<FirebaseAdminService> logger)
     {
         _logger = logger;
-        EnsureFirebaseApp(configuration);
+        _credential = LoadCredential(configuration);
+        _projectId = configuration["Firebase:ProjectId"];
+        _disclaimersParameterKey = configuration["Firebase:RemoteConfig:DisclaimerParameterKey"] ?? DefaultDisclaimersParameterKey;
+
+        EnsureFirebaseApp(_credential);
+
+        _remoteConfigService = new Lazy<FirebaseRemoteConfigService?>(CreateRemoteConfigService, LazyThreadSafetyMode.ExecutionAndPublication);
+        _serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
     }
 
     public async Task SetAdminClaimAsync(string uid, bool isAdmin, CancellationToken cancellationToken = default)
@@ -34,27 +59,122 @@ public class FirebaseAdminService : IFirebaseAdminService
         await FirebaseAuth.DefaultInstance.SetCustomUserClaimsAsync(uid, claims, cancellationToken);
     }
 
-    private static void EnsureFirebaseApp(IConfiguration configuration)
+    public async Task<IReadOnlyList<RemoteConfigDisclaimerDto>> GetDisclaimersAsync(CancellationToken cancellationToken = default)
     {
-        if (FirebaseApp.DefaultInstance != null)
+        var template = await GetRemoteConfigTemplateAsync(cancellationToken);
+        return ParseDisclaimers(template);
+    }
+
+    public async Task<RemoteConfigDisclaimerDto?> GetDisclaimerAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(id))
         {
-            return;
+            return null;
         }
 
-        var credentialsPath = configuration["Firebase:CredentialsPath"];
+        var disclaimers = await GetDisclaimersAsync(cancellationToken);
+        return disclaimers.FirstOrDefault(d => string.Equals(d.Id, id, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<RemoteConfigDisclaimerDto> CreateDisclaimerAsync(CreateRemoteConfigDisclaimerRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var template = await GetRemoteConfigTemplateAsync(cancellationToken);
+        var disclaimers = ParseDisclaimers(template).ToList();
+
+        var disclaimer = new RemoteConfigDisclaimerDto
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Message = NormalizeMessage(request.Message),
+            Locale = NormalizeLocale(request.Locale),
+            LastUpdatedUtc = DateTime.UtcNow,
+        };
+
+        disclaimers.Add(disclaimer);
+        await SaveDisclaimersAsync(template, disclaimers, cancellationToken);
+        return disclaimer;
+    }
+
+    public async Task<RemoteConfigDisclaimerDto> UpdateDisclaimerAsync(string id, UpdateRemoteConfigDisclaimerRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var template = await GetRemoteConfigTemplateAsync(cancellationToken);
+        var disclaimers = ParseDisclaimers(template).ToList();
+        var index = disclaimers.FindIndex(d => string.Equals(d.Id, id, StringComparison.OrdinalIgnoreCase));
+
+        if (index < 0)
+        {
+            throw new KeyNotFoundException($"Disclaimer '{id}' was not found in Remote Config.");
+        }
+
+        var updated = disclaimers[index] with
+        {
+            Message = NormalizeMessage(request.Message),
+            Locale = NormalizeLocale(request.Locale),
+            LastUpdatedUtc = DateTime.UtcNow,
+        };
+
+        disclaimers[index] = updated;
+        await SaveDisclaimersAsync(template, disclaimers, cancellationToken);
+        return updated;
+    }
+
+    public async Task<bool> DeleteDisclaimerAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        var template = await GetRemoteConfigTemplateAsync(cancellationToken);
+        var disclaimers = ParseDisclaimers(template).ToList();
+        var removed = disclaimers.RemoveAll(d => string.Equals(d.Id, id, StringComparison.OrdinalIgnoreCase));
+
+        if (removed <= 0)
+        {
+            return false;
+        }
+
+        await SaveDisclaimersAsync(template, disclaimers, cancellationToken);
+        return true;
+    }
+
+    private GoogleCredential? LoadCredential(IConfiguration configuration)
+    {
         var credentialsJson = configuration["Firebase:CredentialsJson"];
+        var credentialsPath = configuration["Firebase:CredentialsPath"];
 
-        GoogleCredential? credential = null;
-        if (!string.IsNullOrWhiteSpace(credentialsJson))
+        try
         {
-            credential = GoogleCredential.FromJson(credentialsJson);
+            if (!string.IsNullOrWhiteSpace(credentialsJson))
+            {
+                return GoogleCredential.FromJson(credentialsJson);
+            }
+
+            if (!string.IsNullOrWhiteSpace(credentialsPath) && File.Exists(credentialsPath))
+            {
+                return GoogleCredential.FromFile(credentialsPath);
+            }
         }
-        else if (!string.IsNullOrWhiteSpace(credentialsPath) && File.Exists(credentialsPath))
+        catch (Exception ex)
         {
-            credential = GoogleCredential.FromFile(credentialsPath);
+            _logger.LogError(ex, "Failed to load Firebase credentials.");
         }
 
-        if (credential == null)
+        if (string.IsNullOrWhiteSpace(credentialsJson) && string.IsNullOrWhiteSpace(credentialsPath))
+        {
+            _logger.LogWarning("Firebase credentials are not configured. Remote Config operations will be disabled.");
+        }
+
+        return null;
+    }
+
+    private static void EnsureFirebaseApp(GoogleCredential? credential)
+    {
+        if (FirebaseApp.DefaultInstance != null || credential is null)
         {
             return;
         }
@@ -63,5 +183,122 @@ public class FirebaseAdminService : IFirebaseAdminService
         {
             Credential = credential,
         });
+    }
+
+    private FirebaseRemoteConfigService? CreateRemoteConfigService()
+    {
+        if (_credential is null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(_projectId))
+        {
+            _logger.LogWarning("Firebase:ProjectId configuration is missing; Remote Config operations are disabled.");
+            return null;
+        }
+
+        try
+        {
+            return new FirebaseRemoteConfigService(new BaseClientService.Initializer
+            {
+                HttpClientInitializer = _credential.CreateScoped(FirebaseRemoteConfigService.Scope.Firebase),
+                ApplicationName = "Crew.Api Remote Config",
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Firebase Remote Config client.");
+            return null;
+        }
+    }
+
+    private FirebaseRemoteConfigService GetRemoteConfigServiceOrThrow()
+    {
+        var service = _remoteConfigService.Value;
+        if (service is null)
+        {
+            throw new InvalidOperationException("Firebase Remote Config service is not configured. Ensure Firebase credentials and project ID are provided.");
+        }
+
+        return service;
+    }
+
+    private string GetProjectConfigResourceName()
+    {
+        if (string.IsNullOrWhiteSpace(_projectId))
+        {
+            throw new InvalidOperationException("Firebase:ProjectId configuration is required for Remote Config operations.");
+        }
+
+        return $"projects/{_projectId}/remoteConfig";
+    }
+
+    private async Task<RemoteConfig> GetRemoteConfigTemplateAsync(CancellationToken cancellationToken)
+    {
+        var service = GetRemoteConfigServiceOrThrow();
+        var request = service.Projects.GetRemoteConfig(GetProjectConfigResourceName());
+        return await request.ExecuteAsync(cancellationToken);
+    }
+
+    private IReadOnlyList<RemoteConfigDisclaimerDto> ParseDisclaimers(RemoteConfig template)
+    {
+        if (template.Parameters != null &&
+            template.Parameters.TryGetValue(_disclaimersParameterKey, out var parameter) &&
+            parameter?.DefaultValue?.Value is string json &&
+            !string.IsNullOrWhiteSpace(json))
+        {
+            try
+            {
+                var disclaimers = JsonSerializer.Deserialize<List<RemoteConfigDisclaimerDto>>(json, _serializerOptions) ?? new List<RemoteConfigDisclaimerDto>();
+                return disclaimers
+                    .Where(d => !string.IsNullOrWhiteSpace(d.Id) && !string.IsNullOrWhiteSpace(d.Message))
+                    .ToList();
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Failed to parse Remote Config disclaimers from parameter {ParameterKey}.", _disclaimersParameterKey);
+            }
+        }
+
+        return new List<RemoteConfigDisclaimerDto>();
+    }
+
+    private async Task SaveDisclaimersAsync(RemoteConfig template, IEnumerable<RemoteConfigDisclaimerDto> disclaimers, CancellationToken cancellationToken)
+    {
+        template.Parameters ??= new Dictionary<string, RemoteConfigParameter>();
+
+        var ordered = disclaimers
+            .OrderByDescending(d => d.LastUpdatedUtc)
+            .ToList();
+
+        template.Parameters[_disclaimersParameterKey] = new RemoteConfigParameter
+        {
+            DefaultValue = new RemoteConfigParameterValue
+            {
+                Value = JsonSerializer.Serialize(ordered, _serializerOptions),
+            },
+            Description = "Managed disclaimers for the Crew application.",
+        };
+
+        var service = GetRemoteConfigServiceOrThrow();
+        var request = service.Projects.UpdateRemoteConfig(template, GetProjectConfigResourceName());
+        request.IfMatch = string.IsNullOrEmpty(template.ETag) ? "*" : template.ETag;
+        await request.ExecuteAsync(cancellationToken);
+    }
+
+    private static string NormalizeMessage(string message)
+    {
+        return string.IsNullOrWhiteSpace(message) ? string.Empty : message.Trim();
+    }
+
+    private static string? NormalizeLocale(string? locale)
+    {
+        if (string.IsNullOrWhiteSpace(locale))
+        {
+            return null;
+        }
+
+        return locale.Trim();
     }
 }

--- a/Crew.Api/Services/IFirebaseAdminService.cs
+++ b/Crew.Api/Services/IFirebaseAdminService.cs
@@ -1,6 +1,13 @@
+using Crew.Api.Models.RemoteConfig;
+
 namespace Crew.Api.Services;
 
 public interface IFirebaseAdminService
 {
     Task SetAdminClaimAsync(string uid, bool isAdmin, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<RemoteConfigDisclaimerDto>> GetDisclaimersAsync(CancellationToken cancellationToken = default);
+    Task<RemoteConfigDisclaimerDto?> GetDisclaimerAsync(string id, CancellationToken cancellationToken = default);
+    Task<RemoteConfigDisclaimerDto> CreateDisclaimerAsync(CreateRemoteConfigDisclaimerRequest request, CancellationToken cancellationToken = default);
+    Task<RemoteConfigDisclaimerDto> UpdateDisclaimerAsync(string id, UpdateRemoteConfigDisclaimerRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteDisclaimerAsync(string id, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- add the Google Firebase Remote Config client dependency
- extend the Firebase admin service to load and persist disclaimers in Remote Config
- expose admin endpoints and DTOs for creating, updating, listing, and deleting Remote Config disclaimers

## Testing
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68decd626a10832ca7c8360ca23bebb4