### PR TITLE
Use AppDbContext for authenticated user lookup

### DIFF
--- a/Crew.Api/Controllers/UserController.cs
+++ b/Crew.Api/Controllers/UserController.cs
@@ -1,8 +1,9 @@
 ﻿using System.Security.Claims;
 using Crew.Api.Models.Authentication;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Crew.Api.Data.DbContexts;
+using Microsoft.EntityFrameworkCore;
 
 namespace Crew.Api.Controllers;
 
@@ -12,12 +13,12 @@ namespace Crew.Api.Controllers;
 public class UserController
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly AppDbContext _dbContext;
 
-    public UserController(IHttpContextAccessor httpContextAccessor, UserManager<ApplicationUser> userManager)
+    public UserController(IHttpContextAccessor httpContextAccessor, AppDbContext dbContext)
     {
         _httpContextAccessor = httpContextAccessor;
-        _userManager = userManager;
+        _dbContext = dbContext;
     }
 
     [HttpGet]
@@ -30,20 +31,39 @@ public class UserController
         }
 
         var claimsPrincipal = httpContext.User;
-        var firebaseId = claimsPrincipal.Claims.First(x => x.Type == "user_id").Value;
-        var email = claimsPrincipal.Claims.First(x => x.Type == ClaimTypes.Email).Value;
+        var firebaseId = claimsPrincipal.Claims.FirstOrDefault(x => x.Type == "user_id")?.Value;
+        var email = claimsPrincipal.Claims.FirstOrDefault(x => x.Type == ClaimTypes.Email)?.Value;
 
-        var user = await _userManager.FindByEmailAsync(email);
+        if (string.IsNullOrWhiteSpace(firebaseId) && string.IsNullOrWhiteSpace(email))
+        {
+            throw new InvalidOperationException("Authenticated user is missing Firebase UID and email claims.");
+        }
+
+        var cancellationToken = httpContext.RequestAborted;
+
+        var user = !string.IsNullOrWhiteSpace(firebaseId)
+            ? await _dbContext.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Uid == firebaseId, cancellationToken)
+            : null;
+
+        if (user == null && !string.IsNullOrWhiteSpace(email))
+        {
+            user = await _dbContext.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Email == email, cancellationToken);
+        }
+
         if (user == null)
         {
-            throw new InvalidOperationException($"No user found with email '{email}'.");
+            throw new InvalidOperationException("No user found for the authenticated principal.");
         }
 
         return new()
         {
-            FirebaseId = firebaseId,
-            Email = email,
-            AspNetIdentityId = user.Id,
+            FirebaseId = firebaseId ?? user.Uid,
+            Email = user.Email,
+            AspNetIdentityId = user.Uid,
             RespondedAt = DateTime.Now,
         };
     }


### PR DESCRIPTION
## Summary
- replace the UserManager dependency in `UserController` with `AppDbContext`
- load the authenticated user from the synchronized `Users` table and map it to `LoginDetail`

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dedcd00180832c992cc81b52e66c35