### PR TITLE
Associate seeded events with Firebase users

### DIFF
--- a/Crew.Api/Controllers/EventsController.cs
+++ b/Crew.Api/Controllers/EventsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Crew.Api.Data.DbContexts;
+using Crew.Api.Entities;
 using Crew.Api.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -20,22 +21,22 @@ public class EventsController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<Event>>> GetAll()
+    public async Task<ActionResult<IEnumerable<EventModal>>> GetAll()
     {
         var entities = await _context.Events.ToListAsync();
-        return Ok(entities.Select(MapToDto));
+        return Ok(entities.Select(MapToModal));
     }
 
     [HttpGet("{id}")]
-    public async Task<ActionResult<Event>> GetById(int id)
+    public async Task<ActionResult<EventModal>> GetById(int id)
     {
         var entity = await _context.Events.FindAsync(id);
         if (entity == null) return NotFound();
-        return Ok(MapToDto(entity));
+        return Ok(MapToModal(entity));
     }
 
     [HttpPost]
-    public async Task<ActionResult<Event>> Create(Event newEvent)
+    public async Task<ActionResult<EventModal>> Create(EventModal newEvent)
     {
         SanitizeEvent(newEvent);
 
@@ -44,7 +45,7 @@ public class EventsController : ControllerBase
             return BadRequest("User UID is required.");
         }
 
-        var entity = new EventEntity();
+        var entity = new Event();
         ApplyDtoToEntity(newEvent, entity, isUpdate: false);
 
         entity.Id = _context.Events.Any() ? _context.Events.Max(e => e.Id) + 1 : 1;
@@ -70,12 +71,12 @@ public class EventsController : ControllerBase
         _context.Events.Add(entity);
         await _context.SaveChangesAsync();
 
-        var dto = MapToDto(entity);
+        var dto = MapToModal(entity);
         return CreatedAtAction(nameof(GetById), new { id = dto.Id }, dto);
     }
 
     [HttpPut("{id}")]
-    public async Task<IActionResult> Update(int id, Event updatedEvent)
+    public async Task<IActionResult> Update(int id, EventModal updatedEvent)
     {
         var entity = await _context.Events.FindAsync(id);
         if (entity == null) return NotFound();
@@ -106,7 +107,7 @@ public class EventsController : ControllerBase
     }
 
     [HttpGet("search")]
-    public async Task<ActionResult<IEnumerable<Event>>> SearchEvents(
+    public async Task<ActionResult<IEnumerable<EventModal>>> SearchEvents(
         string? query,
         double? lat,
         double? lng,
@@ -155,10 +156,10 @@ public class EventsController : ControllerBase
                 .ToList();
         }
 
-        return Ok(result.Select(MapToDto));
+        return Ok(result.Select(MapToModal));
     }
 
-    private static void SanitizeEvent(Event eventToSanitize)
+    private static void SanitizeEvent(EventModal eventToSanitize)
     {
         eventToSanitize.Title = eventToSanitize.Title?.Trim() ?? string.Empty;
         eventToSanitize.Type = eventToSanitize.Type?.Trim() ?? string.Empty;
@@ -170,7 +171,7 @@ public class EventsController : ControllerBase
         eventToSanitize.UserUid = eventToSanitize.UserUid?.Trim() ?? string.Empty;
     }
 
-    private static void ApplyDtoToEntity(Event source, EventEntity target, bool isUpdate)
+    private static void ApplyDtoToEntity(EventModal source, Event target, bool isUpdate)
     {
         target.Title = source.Title;
         target.Type = source.Type;
@@ -211,7 +212,7 @@ public class EventsController : ControllerBase
         }
     }
 
-    private static Event MapToDto(EventEntity entity)
+    private static EventModal MapToModal(Event entity)
         => new()
         {
             Id = entity.Id,

--- a/Crew.Api/Data/DbContexts/AppDbContext.cs
+++ b/Crew.Api/Data/DbContexts/AppDbContext.cs
@@ -1,3 +1,4 @@
+using Crew.Api.Entities;
 using Crew.Api.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,7 +13,7 @@ public class AppDbContext : DbContext
     public DbSet<UserAccount> Users => Set<UserAccount>();
     public DbSet<Role> Roles => Set<Role>();
     public DbSet<UserRoleAssignment> UserRoles => Set<UserRoleAssignment>();
-    public DbSet<EventEntity> Events => Set<EventEntity>();
+    public DbSet<Event> Events => Set<Event>();
     public DbSet<Comment> Comments => Set<Comment>();
     public DbSet<TestData> TestData { get; set; }
     public DbSet<SubscriptionPlan> SubscriptionPlans => Set<SubscriptionPlan>();
@@ -75,7 +76,7 @@ public class AppDbContext : DbContext
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
-        modelBuilder.Entity<EventEntity>(entity =>
+        modelBuilder.Entity<Event>(entity =>
         {
             entity.HasOne(e => e.User)
                 .WithMany(u => u.Events)

--- a/Crew.Api/Data/DbContexts/AppDbContext.cs
+++ b/Crew.Api/Data/DbContexts/AppDbContext.cs
@@ -12,7 +12,7 @@ public class AppDbContext : DbContext
     public DbSet<UserAccount> Users => Set<UserAccount>();
     public DbSet<Role> Roles => Set<Role>();
     public DbSet<UserRoleAssignment> UserRoles => Set<UserRoleAssignment>();
-    public DbSet<Event> Events => Set<Event>();
+    public DbSet<EventEntity> Events => Set<EventEntity>();
     public DbSet<Comment> Comments => Set<Comment>();
     public DbSet<TestData> TestData { get; set; }
     public DbSet<SubscriptionPlan> SubscriptionPlans => Set<SubscriptionPlan>();
@@ -68,9 +68,14 @@ public class AppDbContext : DbContext
                 .WithMany(u => u.Comments)
                 .HasForeignKey(c => c.UserUid)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(c => c.Event)
+                .WithMany(e => e.Comments)
+                .HasForeignKey(c => c.EventId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
-        modelBuilder.Entity<Event>(entity =>
+        modelBuilder.Entity<EventEntity>(entity =>
         {
             entity.HasOne(e => e.User)
                 .WithMany(u => u.Events)
@@ -79,4 +84,3 @@ public class AppDbContext : DbContext
         });
     }
 }
-

--- a/Crew.Api/Data/DbContexts/AppDbContext.cs
+++ b/Crew.Api/Data/DbContexts/AppDbContext.cs
@@ -69,6 +69,14 @@ public class AppDbContext : DbContext
                 .HasForeignKey(c => c.UserUid)
                 .OnDelete(DeleteBehavior.Cascade);
         });
+
+        modelBuilder.Entity<Event>(entity =>
+        {
+            entity.HasOne(e => e.User)
+                .WithMany(u => u.Events)
+                .HasForeignKey(e => e.UserUid)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
     }
 }
 

--- a/Crew.Api/Entities/Event.cs
+++ b/Crew.Api/Entities/Event.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Crew.Api.Models;
 
-namespace Crew.Api.Models;
+namespace Crew.Api.Entities;
 
-/// <summary>
-/// Simplified event model exposed to the client.
-/// </summary>
 public class Event
 {
     public int Id { get; set; }
@@ -28,4 +26,7 @@ public class Event
 
     public List<string> ImageUrls { get; set; } = new();
     public string CoverImageUrl { get; set; } = string.Empty;
+
+    public UserAccount? User { get; set; }
+    public ICollection<Comment> Comments { get; set; } = new List<Comment>();
 }

--- a/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
@@ -51,7 +51,7 @@ namespace Crew.Api.Migrations
                     b.ToTable("Comments");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -289,8 +289,8 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
-                    b.HasOne("Crew.Api.Models.Event", "Event")
-                        .WithMany()
+                    b.HasOne("Crew.Api.Models.EventEntity", "Event")
+                        .WithMany("Comments")
                         .HasForeignKey("EventId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -306,13 +306,15 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
                 {
                     b.HasOne("Crew.Api.Models.UserAccount", "User")
                         .WithMany("Events")
                         .HasForeignKey("UserUid")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.Navigation("Comments");
 
                     b.Navigation("User");
                 });

--- a/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
@@ -51,7 +51,7 @@ namespace Crew.Api.Migrations
                     b.ToTable("Comments");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
+            modelBuilder.Entity("Crew.Api.Entities.Event", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -289,7 +289,7 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
-                    b.HasOne("Crew.Api.Models.EventEntity", "Event")
+                    b.HasOne("Crew.Api.Entities.Event", "Event")
                         .WithMany("Comments")
                         .HasForeignKey("EventId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -306,7 +306,7 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
+            modelBuilder.Entity("Crew.Api.Entities.Event", b =>
                 {
                     b.HasOne("Crew.Api.Models.UserAccount", "User")
                         .WithMany("Events")

--- a/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
@@ -110,7 +110,13 @@ namespace Crew.Api.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("UserUid")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
                     b.HasKey("Id");
+
+                    b.HasIndex("UserUid");
 
                     b.ToTable("Events");
                 });
@@ -300,6 +306,17 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+                {
+                    b.HasOne("Crew.Api.Models.UserAccount", "User")
+                        .WithMany("Events")
+                        .HasForeignKey("UserUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.UserRoleAssignment", b =>
                 {
                     b.HasOne("Crew.Api.Models.Role", "Role")
@@ -351,6 +368,8 @@ namespace Crew.Api.Migrations
             modelBuilder.Entity("Crew.Api.Models.UserAccount", b =>
                 {
                     b.Navigation("Comments");
+
+                    b.Navigation("Events");
 
                     b.Navigation("Roles");
 

--- a/Crew.Api/Migrations/20250924215436_Initial.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.cs
@@ -83,11 +83,18 @@ namespace Crew.Api.Migrations
                     Latitude = table.Column<double>(type: "REAL", nullable: false),
                     Longitude = table.Column<double>(type: "REAL", nullable: false),
                     ImageUrls = table.Column<string>(type: "TEXT", nullable: false),
-                    CoverImageUrl = table.Column<string>(type: "TEXT", nullable: false)
+                    CoverImageUrl = table.Column<string>(type: "TEXT", nullable: false),
+                    UserUid = table.Column<string>(type: "TEXT", nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_Events", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Events_Users_UserUid",
+                        column: x => x.UserUid,
+                        principalTable: "Users",
+                        principalColumn: "Uid",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -190,6 +197,11 @@ namespace Crew.Api.Migrations
             migrationBuilder.CreateIndex(
                 name: "IX_Comments_UserUid",
                 table: "Comments",
+                column: "UserUid");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_UserUid",
+                table: "Events",
                 column: "UserUid");
 
             migrationBuilder.CreateIndex(

--- a/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -48,7 +48,7 @@ namespace Crew.Api.Migrations
                     b.ToTable("Comments");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -286,8 +286,8 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
-                    b.HasOne("Crew.Api.Models.Event", "Event")
-                        .WithMany()
+                    b.HasOne("Crew.Api.Models.EventEntity", "Event")
+                        .WithMany("Comments")
                         .HasForeignKey("EventId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -303,13 +303,15 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
                 {
                     b.HasOne("Crew.Api.Models.UserAccount", "User")
                         .WithMany("Events")
                         .HasForeignKey("UserUid")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.Navigation("Comments");
 
                     b.Navigation("User");
                 });

--- a/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -107,7 +107,13 @@ namespace Crew.Api.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("UserUid")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
                     b.HasKey("Id");
+
+                    b.HasIndex("UserUid");
 
                     b.ToTable("Events");
                 });
@@ -297,6 +303,17 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.Event", b =>
+                {
+                    b.HasOne("Crew.Api.Models.UserAccount", "User")
+                        .WithMany("Events")
+                        .HasForeignKey("UserUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.UserRoleAssignment", b =>
                 {
                     b.HasOne("Crew.Api.Models.Role", "Role")
@@ -348,6 +365,8 @@ namespace Crew.Api.Migrations
             modelBuilder.Entity("Crew.Api.Models.UserAccount", b =>
                 {
                     b.Navigation("Comments");
+
+                    b.Navigation("Events");
 
                     b.Navigation("Roles");
 

--- a/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -48,7 +48,7 @@ namespace Crew.Api.Migrations
                     b.ToTable("Comments");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
+            modelBuilder.Entity("Crew.Api.Entities.Event", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -286,7 +286,7 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
-                    b.HasOne("Crew.Api.Models.EventEntity", "Event")
+                    b.HasOne("Crew.Api.Entities.Event", "Event")
                         .WithMany("Comments")
                         .HasForeignKey("EventId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -303,7 +303,7 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Crew.Api.Models.EventEntity", b =>
+            modelBuilder.Entity("Crew.Api.Entities.Event", b =>
                 {
                     b.HasOne("Crew.Api.Models.UserAccount", "User")
                         .WithMany("Events")

--- a/Crew.Api/Models/Comment.cs
+++ b/Crew.Api/Models/Comment.cs
@@ -7,9 +7,9 @@ public class Comment
     public int Id { get; set; }
     public int EventId { get; set; }
     public string UserUid { get; set; } = string.Empty;
-    public string Content { get; set; } = "";
+    public string Content { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-    public Event? Event { get; set; }
+    public EventEntity? Event { get; set; }
     public UserAccount? User { get; set; }
 }

--- a/Crew.Api/Models/Comment.cs
+++ b/Crew.Api/Models/Comment.cs
@@ -1,4 +1,5 @@
 using System;
+using Crew.Api.Entities;
 
 namespace Crew.Api.Models;
 
@@ -10,6 +11,6 @@ public class Comment
     public string Content { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-    public EventEntity? Event { get; set; }
+    public Event? Event { get; set; }
     public UserAccount? User { get; set; }
 }

--- a/Crew.Api/Models/Event.cs
+++ b/Crew.Api/Models/Event.cs
@@ -13,6 +13,7 @@ public class Event
     public string Location { get; set; } = ""; // 活动地点
     public string Description { get; set; } = ""; // 活动简介
     public int ExpectedParticipants { get; set; } = 0; // 预计参与人数
+    public string UserUid { get; set; } = string.Empty; // 创建活动的用户 UID
 
     // 时间字段
     public DateTime StartTime { get; set; } // 开始时间
@@ -27,4 +28,6 @@ public class Event
     // 图片字段
     public List<string> ImageUrls { get; set; } = new(); // 图片链接列表
     public string CoverImageUrl { get; set; } = ""; // 封面图链接
+
+    public UserAccount? User { get; set; }
 }

--- a/Crew.Api/Models/EventEntity.cs
+++ b/Crew.Api/Models/EventEntity.cs
@@ -3,10 +3,7 @@ using System.Collections.Generic;
 
 namespace Crew.Api.Models;
 
-/// <summary>
-/// Simplified event model exposed to the client.
-/// </summary>
-public class Event
+public class EventEntity
 {
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
@@ -28,4 +25,7 @@ public class Event
 
     public List<string> ImageUrls { get; set; } = new();
     public string CoverImageUrl { get; set; } = string.Empty;
+
+    public UserAccount? User { get; set; }
+    public ICollection<Comment> Comments { get; set; } = new List<Comment>();
 }

--- a/Crew.Api/Models/EventModal.cs
+++ b/Crew.Api/Models/EventModal.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 
 namespace Crew.Api.Models;
 
-public class EventEntity
+/// <summary>
+/// Simplified event model exposed to the client.
+/// </summary>
+public class EventModal
 {
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
@@ -25,7 +28,4 @@ public class EventEntity
 
     public List<string> ImageUrls { get; set; } = new();
     public string CoverImageUrl { get; set; } = string.Empty;
-
-    public UserAccount? User { get; set; }
-    public ICollection<Comment> Comments { get; set; } = new List<Comment>();
 }

--- a/Crew.Api/Models/UserAccount.cs
+++ b/Crew.Api/Models/UserAccount.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Crew.Api.Entities;
 
 namespace Crew.Api.Models;
 
@@ -43,7 +44,7 @@ public class UserAccount
 
     public ICollection<Comment> Comments { get; set; } = new List<Comment>();
 
-    public ICollection<EventEntity> Events { get; set; } = new List<EventEntity>();
+    public ICollection<Event> Events { get; set; } = new List<Event>();
 }
 
 public static class UserStatuses

--- a/Crew.Api/Models/UserAccount.cs
+++ b/Crew.Api/Models/UserAccount.cs
@@ -43,7 +43,7 @@ public class UserAccount
 
     public ICollection<Comment> Comments { get; set; } = new List<Comment>();
 
-    public ICollection<Event> Events { get; set; } = new List<Event>();
+    public ICollection<EventEntity> Events { get; set; } = new List<EventEntity>();
 }
 
 public static class UserStatuses

--- a/Crew.Api/Models/UserAccount.cs
+++ b/Crew.Api/Models/UserAccount.cs
@@ -42,6 +42,8 @@ public class UserAccount
     public ICollection<UserSubscription> Subscriptions { get; set; } = new List<UserSubscription>();
 
     public ICollection<Comment> Comments { get; set; } = new List<Comment>();
+
+    public ICollection<Event> Events { get; set; } = new List<Event>();
 }
 
 public static class UserStatuses

--- a/Crew.Api/Utils/SeedDataService.cs
+++ b/Crew.Api/Utils/SeedDataService.cs
@@ -44,7 +44,7 @@ public static class SeedDataService
         {
             var baseTime = DateTime.UtcNow.Date.AddHours(10);
 
-            var seededEvents = new List<Event>
+            var seededEvents = new List<EventEntity>
             {
                 CreateEvent(
                     id: 1,
@@ -291,7 +291,7 @@ public static class SeedDataService
 
     }
 
-    private static Event CreateEvent(
+    private static EventEntity CreateEvent(
         int id,
         string title,
         string type,
@@ -330,7 +330,7 @@ public static class SeedDataService
             endTime = startTime;
         }
 
-        return new Event
+        return new EventEntity
         {
             Id = id,
             Title = title,

--- a/Crew.Api/Utils/SeedDataService.cs
+++ b/Crew.Api/Utils/SeedDataService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Crew.Api.Data.DbContexts;
+using Crew.Api.Entities;
 using Crew.Api.Models;
 
 namespace Crew.Api.Utils;
@@ -44,7 +45,7 @@ public static class SeedDataService
         {
             var baseTime = DateTime.UtcNow.Date.AddHours(10);
 
-            var seededEvents = new List<EventEntity>
+            var seededEvents = new List<Event>
             {
                 CreateEvent(
                     id: 1,
@@ -291,7 +292,7 @@ public static class SeedDataService
 
     }
 
-    private static EventEntity CreateEvent(
+    private static Event CreateEvent(
         int id,
         string title,
         string type,
@@ -330,7 +331,7 @@ public static class SeedDataService
             endTime = startTime;
         }
 
-        return new EventEntity
+        return new Event
         {
             Id = id,
             Title = title,

--- a/Crew.Api/Utils/SeedDataService.cs
+++ b/Crew.Api/Utils/SeedDataService.cs
@@ -10,6 +10,36 @@ public static class SeedDataService
 {
     public static void SeedDatabase(AppDbContext context)
     {
+        var userUids = new[]
+        {
+            "znJ7TKLY6CfJA7erPijkGGmHUMo2",
+            "DcklGiovAyY6KK5kRJb1saTE0ue2",
+            "kujZMzf2m4Wkz0iuJ1Xofpe0yb83",
+            "msO0VorfTgdZm9tBfesm60fdbzm1",
+            "Xm26B0NPATNtUhK2YJZjsHFdHXD2",
+            "0cO4ZIGOtWTfISF5XcHEV2JIfMl1",
+            "noOmQhhX1fc5EuCrMEO7n8VScrS2",
+            "0kl6ETYUu2Ugclow94CBgSUoIEo2"
+        };
+
+        if (!context.Users.Any())
+        {
+            var seededUsers = new List<UserAccount>
+            {
+                CreateUser(userUids[0], "admin@casl.io", "admin", "Admin User"),
+                CreateUser(userUids[1], "alice@example.com", "alice", "Alice"),
+                CreateUser(userUids[2], "bob@example.com", "bob", "Bob"),
+                CreateUser(userUids[3], "charlie@example.com", "charlie", "Charlie"),
+                CreateUser(userUids[4], "diana@example.com", "diana", "Diana"),
+                CreateUser(userUids[5], "eric@example.com", "eric", "Eric"),
+                CreateUser(userUids[6], "fiona@example.com", "fiona", "Fiona"),
+                CreateUser(userUids[7], "george@example.com", "george", "George")
+            };
+
+            context.Users.AddRange(seededUsers);
+            context.SaveChanges();
+        }
+
         if (!context.Events.Any())
         {
             var baseTime = DateTime.UtcNow.Date.AddHours(10);
@@ -35,7 +65,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1529927066849-a6c9a73b73a0",
                         "https://images.unsplash.com/photo-1508057198894-247b23fe5ade"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[0]),
                 CreateEvent(
                     id: 2,
                     title: "Museum Tour",
@@ -55,7 +86,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1529429617124-aee30bd7e8f9",
                         "https://images.unsplash.com/photo-1441974231531-c6227db76b6e"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[1]),
                 CreateEvent(
                     id: 3,
                     title: "Coffee Meetup",
@@ -75,7 +107,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1466978913421-dad2ebd01d17",
                         "https://images.unsplash.com/photo-1470337458703-46ad1756a187"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[2]),
                 CreateEvent(
                     id: 4,
                     title: "Art Gallery Walk",
@@ -95,7 +128,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1487412912498-0447578fcca8",
                         "https://images.unsplash.com/photo-1496317899792-9d7dbcd928a1"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[3]),
                 CreateEvent(
                     id: 5,
                     title: "Hiking Adventure",
@@ -115,7 +149,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1489515217757-5fd1be406fef",
                         "https://images.unsplash.com/photo-1469474968028-56623f02e42e"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[4]),
                 CreateEvent(
                     id: 6,
                     title: "Board Games Night",
@@ -135,7 +170,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1489515217757-5fd1be406fef",
                         "https://images.unsplash.com/photo-1521737604893-d14cc237f11d"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[5]),
                 CreateEvent(
                     id: 7,
                     title: "Live Jazz Night",
@@ -150,7 +186,8 @@ public static class SeedDataService
                     latitude: 52.520008,
                     longitude: 13.404954,
                     imageUrls: Array.Empty<string>(),
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[6]),
                 CreateEvent(
                     id: 8,
                     title: "Open Air Concert",
@@ -170,7 +207,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1497032628192-86f99bcd76bc",
                         "https://images.unsplash.com/photo-1506157786151-b8491531f063"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png"),
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[7]),
                 CreateEvent(
                     id: 9,
                     title: "Morning Run Club",
@@ -189,7 +227,8 @@ public static class SeedDataService
                         "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee",
                         "https://images.unsplash.com/photo-1482192596544-9eb780fc7f66"
                     },
-                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png")
+                    coverImageUrl: "https://i.imgur.com/c7BHAnI.png",
+                    userUid: userUids[0])
             };
 
             context.Events.AddRange(seededEvents);
@@ -266,7 +305,8 @@ public static class SeedDataService
         double latitude,
         double longitude,
         IEnumerable<string> imageUrls,
-        string coverImageUrl)
+        string coverImageUrl,
+        string userUid)
     {
         var images = imageUrls?
             .Where(url => !string.IsNullOrWhiteSpace(url))
@@ -307,7 +347,24 @@ public static class SeedDataService
             Latitude = latitude,
             Longitude = longitude,
             ImageUrls = images,
-            CoverImageUrl = cover
+            CoverImageUrl = cover,
+            UserUid = userUid
+        };
+    }
+
+    private static UserAccount CreateUser(string uid, string email, string userName, string displayName)
+    {
+        return new UserAccount
+        {
+            Uid = uid,
+            Email = email,
+            UserName = userName,
+            DisplayName = displayName,
+            Bio = string.Empty,
+            AvatarUrl = AvatarDefaults.FallbackUrl,
+            CoverImageUrl = string.Empty,
+            Status = UserStatuses.Active,
+            CreatedAt = DateTime.UtcNow
         };
     }
 }


### PR DESCRIPTION
## Summary
- add a required user UID to the Event entity and expose navigation to the owning user
- seed default user accounts for the provided Firebase UIDs and associate each seeded event with one of them
- update the EF Core configuration and initial migration snapshot to enforce the new relationship

## Testing
- not run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68def29daf88832c948f164b03ead82e