### PR TITLE
Add user follow system with API endpoints

### DIFF
--- a/Crew.Api/Controllers/UserFollowsController.cs
+++ b/Crew.Api/Controllers/UserFollowsController.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Linq;
+using Crew.Api.Data.DbContexts;
+using Crew.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Crew.Api.Controllers;
+
+[ApiController]
+[Route("api/users/{userUid}")]
+public class UserFollowsController : ControllerBase
+{
+    private readonly AppDbContext _context;
+
+    public UserFollowsController(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet("followers")]
+    public async Task<ActionResult<IEnumerable<UserSummary>>> GetFollowers(string userUid, CancellationToken cancellationToken)
+    {
+        if (!await _context.Users.AsNoTracking().AnyAsync(u => u.Uid == userUid, cancellationToken))
+        {
+            return NotFound();
+        }
+
+        var followers = await _context.UserFollows
+            .AsNoTracking()
+            .Where(f => f.FollowedUid == userUid)
+            .Join(
+                _context.Users.AsNoTracking(),
+                follow => follow.FollowerUid,
+                user => user.Uid,
+                (follow, user) => new { follow.CreatedAt, User = user })
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => MapToSummary(x.User))
+            .ToListAsync(cancellationToken);
+
+        return Ok(followers);
+    }
+
+    [HttpGet("following")]
+    public async Task<ActionResult<IEnumerable<UserSummary>>> GetFollowing(string userUid, CancellationToken cancellationToken)
+    {
+        if (!await _context.Users.AsNoTracking().AnyAsync(u => u.Uid == userUid, cancellationToken))
+        {
+            return NotFound();
+        }
+
+        var following = await _context.UserFollows
+            .AsNoTracking()
+            .Where(f => f.FollowerUid == userUid)
+            .Join(
+                _context.Users.AsNoTracking(),
+                follow => follow.FollowedUid,
+                user => user.Uid,
+                (follow, user) => new { follow.CreatedAt, User = user })
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => MapToSummary(x.User))
+            .ToListAsync(cancellationToken);
+
+        return Ok(following);
+    }
+
+    [HttpPost("following")]
+    public async Task<ActionResult<UserSummary>> FollowUser(
+        string userUid,
+        [FromBody] FollowRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.TargetUid))
+        {
+            return BadRequest("targetUid is required");
+        }
+
+        var followerUid = userUid.Trim();
+        var targetUid = request.TargetUid.Trim();
+
+        if (string.Equals(followerUid, targetUid, StringComparison.Ordinal))
+        {
+            return BadRequest("Users cannot follow themselves.");
+        }
+
+        var follower = await _context.Users.FirstOrDefaultAsync(u => u.Uid == followerUid, cancellationToken);
+        if (follower is null)
+        {
+            return NotFound($"User '{followerUid}' not found.");
+        }
+
+        var target = await _context.Users.FirstOrDefaultAsync(u => u.Uid == targetUid, cancellationToken);
+        if (target is null)
+        {
+            return NotFound($"User '{targetUid}' not found.");
+        }
+
+        var existingFollow = await _context.UserFollows.FindAsync(new object[] { followerUid, targetUid }, cancellationToken);
+        if (existingFollow is not null)
+        {
+            return Conflict("Follow relationship already exists.");
+        }
+
+        _context.UserFollows.Add(new UserFollow
+        {
+            FollowerUid = followerUid,
+            FollowedUid = targetUid,
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return CreatedAtAction(
+            nameof(GetFollowing),
+            new { userUid = followerUid },
+            MapToSummary(target));
+    }
+
+    [HttpDelete("following/{targetUid}")]
+    public async Task<IActionResult> UnfollowUser(string userUid, string targetUid, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(targetUid))
+        {
+            return BadRequest("targetUid is required");
+        }
+
+        var followerUid = userUid.Trim();
+        var normalizedTargetUid = targetUid.Trim();
+
+        var follow = await _context.UserFollows.FindAsync(new object[] { followerUid, normalizedTargetUid }, cancellationToken);
+        if (follow is null)
+        {
+            return NotFound();
+        }
+
+        _context.UserFollows.Remove(follow);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    private static UserSummary MapToSummary(UserAccount user)
+        => new(user.Uid, user.DisplayName, user.UserName, user.AvatarUrl);
+
+    public record FollowRequest(string TargetUid);
+
+    public record UserSummary(string Uid, string DisplayName, string UserName, string AvatarUrl);
+}

--- a/Crew.Api/Controllers/UsersController.cs
+++ b/Crew.Api/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Crew.Api.Data;
 using Crew.Api.Data.DbContexts;
 using Crew.Api.Models;
@@ -28,6 +29,9 @@ public class UsersController : ControllerBase
                 .ThenInclude(r => r.Role)
             .Include(u => u.Subscriptions)
                 .ThenInclude(s => s.Plan)
+            .Include(u => u.Followers)
+            .Include(u => u.Following)
+            .AsSplitQuery()
             .OrderBy(u => u.UserName)
             .ToListAsync(cancellationToken);
 
@@ -43,6 +47,9 @@ public class UsersController : ControllerBase
                 .ThenInclude(r => r.Role)
             .Include(u => u.Subscriptions)
                 .ThenInclude(s => s.Plan)
+            .Include(u => u.Followers)
+            .Include(u => u.Following)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(u => u.Uid == uid, cancellationToken);
 
         if (user is null)
@@ -73,6 +80,9 @@ public class UsersController : ControllerBase
                 .ThenInclude(r => r.Role)
             .Include(u => u.Subscriptions)
                 .ThenInclude(s => s.Plan)
+            .Include(u => u.Followers)
+            .Include(u => u.Following)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(u => u.Uid == normalizedUid, cancellationToken);
 
         if (user is null)
@@ -189,7 +199,9 @@ public class UsersController : ControllerBase
                 .Where(s => s.Plan != null)
                 .Select(s => new SubscriptionResponse(s.Plan!.Key, s.Plan.DisplayName, s.AssignedAt, s.ExpiresAt))
                 .OrderBy(s => s.PlanKey)
-                .ToList());
+                .ToList(),
+            user.Followers.Count,
+            user.Following.Count);
 
     public record EnsureUserRequest(
         string Uid,
@@ -209,7 +221,9 @@ public class UsersController : ControllerBase
         DateTime CreatedAt,
         DateTime? UpdatedAt,
         IReadOnlyCollection<RoleAssignmentResponse> Roles,
-        IReadOnlyCollection<SubscriptionResponse> Subscriptions);
+        IReadOnlyCollection<SubscriptionResponse> Subscriptions,
+        int FollowersCount,
+        int FollowingCount);
 
     public record RoleAssignmentResponse(string Key, string DisplayName, DateTime GrantedAt);
 

--- a/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.Designer.cs
@@ -281,6 +281,26 @@ namespace Crew.Api.Migrations
                     b.ToTable("UserSubscriptions");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.UserFollow", b =>
+                {
+                    b.Property<string>("FollowerUid")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("FollowedUid")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.HasKey("FollowerUid", "FollowedUid");
+
+                    b.HasIndex("FollowedUid");
+
+                    b.ToTable("UserFollows");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
                     b.HasOne("Crew.Api.Models.Event", "Event")
@@ -338,6 +358,25 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.UserFollow", b =>
+                {
+                    b.HasOne("Crew.Api.Models.UserAccount", "Followed")
+                        .WithMany("Followers")
+                        .HasForeignKey("FollowedUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Crew.Api.Models.UserAccount", "Follower")
+                        .WithMany("Following")
+                        .HasForeignKey("FollowerUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Followed");
+
+                    b.Navigation("Follower");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.Role", b =>
                 {
                     b.Navigation("UserRoles");
@@ -350,6 +389,10 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.UserAccount", b =>
                 {
+                    b.Navigation("Followers");
+
+                    b.Navigation("Following");
+
                     b.Navigation("Comments");
 
                     b.Navigation("Roles");

--- a/Crew.Api/Migrations/20250924215436_Initial.cs
+++ b/Crew.Api/Migrations/20250924215436_Initial.cs
@@ -155,6 +155,32 @@ namespace Crew.Api.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "UserFollows",
+                columns: table => new
+                {
+                    FollowerUid = table.Column<string>(type: "TEXT", nullable: false),
+                    FollowedUid = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserFollows", x => new { x.FollowerUid, x.FollowedUid });
+                    table.CheckConstraint("CK_UserFollows_FollowerNotSelf", "\"FollowerUid\" <> \"FollowedUid\"");
+                    table.ForeignKey(
+                        name: "FK_UserFollows_Users_FollowedUid",
+                        column: x => x.FollowedUid,
+                        principalTable: "Users",
+                        principalColumn: "Uid",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserFollows_Users_FollowerUid",
+                        column: x => x.FollowerUid,
+                        principalTable: "Users",
+                        principalColumn: "Uid",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Comments",
                 columns: table => new
                 {
@@ -213,6 +239,11 @@ namespace Crew.Api.Migrations
                 name: "IX_UserSubscriptions_PlanId",
                 table: "UserSubscriptions",
                 column: "PlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserFollows_FollowedUid",
+                table: "UserFollows",
+                column: "FollowedUid");
         }
 
         /// <inheritdoc />
@@ -226,6 +257,9 @@ namespace Crew.Api.Migrations
 
             migrationBuilder.DropTable(
                 name: "UserRoles");
+
+            migrationBuilder.DropTable(
+                name: "UserFollows");
 
             migrationBuilder.DropTable(
                 name: "UserSubscriptions");

--- a/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/Crew.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -278,6 +278,26 @@ namespace Crew.Api.Migrations
                     b.ToTable("UserSubscriptions");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.UserFollow", b =>
+                {
+                    b.Property<string>("FollowerUid")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("FollowedUid")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.HasKey("FollowerUid", "FollowedUid");
+
+                    b.HasIndex("FollowedUid");
+
+                    b.ToTable("UserFollows");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.Comment", b =>
                 {
                     b.HasOne("Crew.Api.Models.Event", "Event")
@@ -335,6 +355,25 @@ namespace Crew.Api.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Crew.Api.Models.UserFollow", b =>
+                {
+                    b.HasOne("Crew.Api.Models.UserAccount", "Followed")
+                        .WithMany("Followers")
+                        .HasForeignKey("FollowedUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Crew.Api.Models.UserAccount", "Follower")
+                        .WithMany("Following")
+                        .HasForeignKey("FollowerUid")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Followed");
+
+                    b.Navigation("Follower");
+                });
+
             modelBuilder.Entity("Crew.Api.Models.Role", b =>
                 {
                     b.Navigation("UserRoles");
@@ -347,6 +386,10 @@ namespace Crew.Api.Migrations
 
             modelBuilder.Entity("Crew.Api.Models.UserAccount", b =>
                 {
+                    b.Navigation("Followers");
+
+                    b.Navigation("Following");
+
                     b.Navigation("Comments");
 
                     b.Navigation("Roles");

--- a/Crew.Api/Models/UserAccount.cs
+++ b/Crew.Api/Models/UserAccount.cs
@@ -42,6 +42,10 @@ public class UserAccount
     public ICollection<UserSubscription> Subscriptions { get; set; } = new List<UserSubscription>();
 
     public ICollection<Comment> Comments { get; set; } = new List<Comment>();
+
+    public ICollection<UserFollow> Followers { get; set; } = new List<UserFollow>();
+
+    public ICollection<UserFollow> Following { get; set; } = new List<UserFollow>();
 }
 
 public static class UserStatuses

--- a/Crew.Api/Models/UserFollow.cs
+++ b/Crew.Api/Models/UserFollow.cs
@@ -1,14 +1,10 @@
 using System;
-using System.ComponentModel.DataAnnotations;
-
 namespace Crew.Api.Models;
 
 public class UserFollow
 {
-    [Key]
     public string FollowerUid { get; set; } = string.Empty;
 
-    [Key]
     public string FollowedUid { get; set; } = string.Empty;
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Crew.Api/Models/UserFollow.cs
+++ b/Crew.Api/Models/UserFollow.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Crew.Api.Models;
+
+public class UserFollow
+{
+    [Key]
+    public string FollowerUid { get; set; } = string.Empty;
+
+    [Key]
+    public string FollowedUid { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public UserAccount? Follower { get; set; }
+
+    public UserAccount? Followed { get; set; }
+}


### PR DESCRIPTION
## Summary
- add a UserFollow entity, database mapping, and migration updates for storing follower relationships
- expose follower and following management endpoints along with follower counts in user responses

## Testing
- `dotnet build` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17a6fb754832cb57405f0108405c6