### PR TITLE
Adjust UserFollow delete behavior to prevent double cascade

### DIFF
--- a/Crew.Api/Data/DbContexts/AppDbContext.cs
+++ b/Crew.Api/Data/DbContexts/AppDbContext.cs
@@ -41,7 +41,7 @@ public class AppDbContext : DbContext
             entity.HasMany(u => u.Followers)
                 .WithOne(f => f.Followed)
                 .HasForeignKey(f => f.FollowedUid)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
             entity.HasMany(u => u.Following)
                 .WithOne(f => f.Follower)
                 .HasForeignKey(f => f.FollowerUid)

--- a/Crew.Api/Migrations/20240227000000_AdjustUserFollowDeleteBehavior.Designer.cs
+++ b/Crew.Api/Migrations/20240227000000_AdjustUserFollowDeleteBehavior.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Crew.Api.Data.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Crew.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240227000000_AdjustUserFollowDeleteBehavior")]
+    partial class AdjustUserFollowDeleteBehavior
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -418,6 +421,18 @@ namespace Crew.Api.Migrations
                     b.Navigation("Roles");
 
                     b.Navigation("Subscriptions");
+                });
+
+            modelBuilder.Entity("Crew.Api.Models.UserFollow", b =>
+                {
+                    b.Navigation("Followed");
+
+                    b.Navigation("Follower");
+                });
+
+            modelBuilder.Entity("Crew.Api.Entities.Event", b =>
+                {
+                    b.Navigation("Comments");
                 });
 #pragma warning restore 612, 618
         }

--- a/Crew.Api/Migrations/20240227000000_AdjustUserFollowDeleteBehavior.cs
+++ b/Crew.Api/Migrations/20240227000000_AdjustUserFollowDeleteBehavior.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Crew.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdjustUserFollowDeleteBehavior : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserFollows_Users_FollowedUid",
+                table: "UserFollows");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserFollows_Users_FollowedUid",
+                table: "UserFollows",
+                column: "FollowedUid",
+                principalTable: "Users",
+                principalColumn: "Uid",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserFollows_Users_FollowedUid",
+                table: "UserFollows");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserFollows_Users_FollowedUid",
+                table: "UserFollows",
+                column: "FollowedUid",
+                principalTable: "Users",
+                principalColumn: "Uid",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- change the `UserFollow` configuration so deleting a followed user is restricted instead of cascading
- add a migration updating the `UserFollows` foreign key to use `Restrict` behavior and refresh the model snapshot

## Testing
- `dotnet ef migrations add AdjustUserFollowDeleteBehavior` *(fails: .NET SDK is not installed in the execution environment)*
- `dotnet ef database update` *(fails: .NET SDK is not installed in the execution environment)*
- Follow/unfollow API check *(blocked: project cannot run without the .NET SDK in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a376378832c9594c62e290108cb