### PR TITLE
Ensure comment creation uses EF-generated IDs

### DIFF
--- a/Crew.Api/Controllers/CommentsController.cs
+++ b/Crew.Api/Controllers/CommentsController.cs
@@ -31,8 +31,7 @@ public class CommentsController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<Comment>> Create(int eventId, Comment newComment)
     {
-        if (!_context.Events.Any(e => e.Id == eventId)) return NotFound("Event not found");
-        newComment.Id = _context.Comments.Any() ? _context.Comments.Max(c => c.Id) + 1 : 1;
+        if (!await _context.Events.AnyAsync(e => e.Id == eventId)) return NotFound("Event not found");
         newComment.EventId = eventId;
         newComment.CreatedAt = DateTime.UtcNow;
         _context.Comments.Add(newComment);


### PR DESCRIPTION
## Summary
- update the comment creation endpoint to await the event existence check
- rely on EF Core to generate comment IDs while still returning the created resource metadata

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e19d9b5394832c8675538a4ad76857