### PR TITLE
Stop manually assigning event IDs

### DIFF
--- a/Crew.Api/Controllers/EventsController.cs
+++ b/Crew.Api/Controllers/EventsController.cs
@@ -48,8 +48,6 @@ public class EventsController : ControllerBase
         var entity = new Event();
         ApplyDtoToEntity(newEvent, entity, isUpdate: false);
 
-        entity.Id = _context.Events.Any() ? _context.Events.Max(e => e.Id) + 1 : 1;
-
         if (entity.StartTime == default)
         {
             entity.StartTime = DateTime.UtcNow;
@@ -72,7 +70,7 @@ public class EventsController : ControllerBase
         await _context.SaveChangesAsync();
 
         var dto = MapToModal(entity);
-        return CreatedAtAction(nameof(GetById), new { id = dto.Id }, dto);
+        return CreatedAtAction(nameof(GetById), new { id = entity.Id }, dto);
     }
 
     [HttpPut("{id}")]


### PR DESCRIPTION
## Summary
- remove the manual ID assignment when creating events so the database manages the key
- ensure the CreatedAtAction response uses the ID from the saved entity

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e19e18d690832c92e32345e7a8dc72