### PR TITLE
Secure event mutation endpoints

### DIFF
--- a/Crew.Api/Models/EventInputModel.cs
+++ b/Crew.Api/Models/EventInputModel.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Crew.Api.Models;
+
+public class EventInputModel
+{
+    public string? Title { get; set; }
+    public string? Type { get; set; }
+    public string? Status { get; set; }
+    public string? Organizer { get; set; }
+    public string? Location { get; set; }
+    public string? Description { get; set; }
+    public int ExpectedParticipants { get; set; }
+
+    public DateTime? StartTime { get; set; }
+    public DateTime? EndTime { get; set; }
+
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+
+    public List<string>? ImageUrls { get; set; } = new();
+    public string? CoverImageUrl { get; set; }
+}


### PR DESCRIPTION
## Summary
- require authentication for event creation, updates, and deletions while enforcing ownership or admin override checks
- ensure new events always use the authenticated user's UID and forbid unauthenticated requests
- add an input DTO that omits the user UID so clients cannot spoof ownership details

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26e80ff5c832c9392188a53256085